### PR TITLE
Add support for 8BitDo Ultimate Controller (2.4GHz mode) and 8BitDo Pro 3 (2.4GHz mode).

### DIFF
--- a/10-evdev-keepalive.rules
+++ b/10-evdev-keepalive.rules
@@ -1,5 +1,14 @@
+### Embedded Ayaneo controller. ###
 # Don't perform MTP probing on the integrated Xbox360 controller.
 SUBSYSTEM=="usb", ATTR{idVendor}=="045e", ATTR{idProduct}=="028e", ENV{MTP_NO_PROBE}="1"
 
 # Setup event device of Xbox360 controller.
 ACTION=="add", KERNEL=="event[0-9]*", SUBSYSTEM=="input", ATTRS{idVendor}=="045e", ATTRS{idProduct}=="028e", ATTRS{manufacturer}=="ZhiXu", ATTRS{product}=="Controller", TAG+="systemd", ENV{SYSTEMD_WANTS}="evdev-keepalive@$kernel.service"
+
+### 8BitDo Ultimate Controller Bluetooth (2.4GHz mode) ###
+SUBSYSTEM=="usb", ATTR{idVendor}=="2dc8", ATTR{idProduct}=="6009", ENV{MTP_NO_PROBE}="1"
+ACTION=="add", SUBSYSTEM=="input", ATTRS{idVendor}=="2dc8", ATTRS{idProduct}=="6009", TAG+="systemd", ENV{SYSTEMD_WANTS}="evdev-keepalive@$kernel.service"
+
+### 8BitDo Pro 3 (2.4GHz mode) ###
+SUBSYSTEM=="usb", ATTR{idVendor}=="2dc8", ATTR{idProduct}=="310b", ENV{MTP_NO_PROBE}="1"
+ACTION=="add", SUBSYSTEM=="input", ATTRS{idVendor}=="2dc8", ATTRS{idProduct}=="310b", TAG+="systemd", ENV{SYSTEMD_WANTS}="evdev-keepalive@$kernel.service"


### PR DESCRIPTION
I have these two controllers and they present the same issue where if they don't get used immediately they disconnect. It turns out, this tool can actually fix it.

I've tested it on my local machine with custom rules that call the same service like the embedded Ayaneo controller and it seems to work, they won't immediately disconnect when there's no game or Steam running anymore for me.

I've tried to organize the rules by grouping the subsystem and action rule pairs into different sections for each controller, please let me know if it's preferable to do this in another way.

I've also simplified the rules for the new controllers because they can just match the vendor and product IDs I think. Interestingly enough, I've noticed that the way the Pro 3 dongle works is that disconnects itself when a controller connects and then reconnects with a different product ID, so it acts like an idle device when disconnected and a controller when connected. This allows nicely matching a specific product ID without worrying about matching the disconnected dongle by accident.

This also seems to work fine for the Ultimate, which I'd been using for a while with evdev-keepalive successfully.

Please let me know if there's any issues or improvements needed. I hope this proves useful for distros like ChimeraOS as well.